### PR TITLE
Add issue templates, update docs version on release

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,34 @@
+---
+name: Bug Report
+about: Submit a bug report for the OpenStack Odoo Client library for Python
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+## Description
+
+A clear and concise description of what the bug is.
+
+## To Reproduce
+
+Steps to reproduce the behavior.
+
+## Expected Behavior
+
+A clear and concise description of what you expected to happen.
+
+## Actual Behaviour
+
+An example of what actually happens.
+
+## Environment
+
+ - OS: [e.g. Ubuntu 24.04 LTS]
+ - Python Version: [e.g. 3.14]
+ - OpenStack Odoo Client Version: [e.g. 0.2.1]
+
+## Additional Information
+
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -1,0 +1,48 @@
+---
+name: Release
+about: Tag a new release
+title: 'Tag v<version>'
+labels: ''
+assignees: ''
+
+---
+
+<!-- Replace <version> with the new version to be released, e.g. 0.3.0 -->
+
+1. [ ] Set the version to tag as a variable:
+   ```bash
+   VERSION=<version>
+   ```
+1. [ ] Checkout the latest `main` branch:
+   ```bash
+   git fetch && git checkout origin/main
+   ```
+1. [ ] Create and checkout a new branch for tagging the release:
+   ```bash
+   git branch tag-${VERSION} && git checkout tag-${VERSION}
+   ```
+1. [ ] Generate release notes for the new version:
+   ```bash
+   uv run towncrier build --version ${VERSION}
+   ```
+1. [ ] Commit changes:
+   ```bash
+   git add -A . && git commit -m "Tag v${VERSION}"
+   ```
+1. [ ] Push changes:
+   ```bash
+   git push -u origin tag-${VERSION}
+   ```
+1. [ ] Make a new release tag PR on GitHub and link it here: (PR URL)
+1. [ ] Merge the release tag PR.
+1. [ ] Checkout the latest `main` branch:
+   ```bash
+   git fetch && git checkout origin/main
+   ```
+1. [ ] Tag and push the latest release:
+   ```bash
+   git tag ${VERSION} && git push origin ${VERSION}
+   ```
+1. [ ] Confirm that the new version was released to PyPI: https://pypi.org/project/python-openstack-odooclient
+1. [ ] Confirm that a new release was created on GitHub, and that the release notes are correct: https://github.com/catalyst-cloud/python-openstack-odooclient/releases
+1. [ ] Confirm that the docs website has been updated, and the Changelog page has the latest changes: https://catalyst-cloud.github.io/python-openstack-odooclient

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -113,6 +113,6 @@ jobs:
       - name: Create virtual environment
         run: uv sync --only-dev
       - name: Publish the docs to GitHub Pages
-        run: uv run mike deploy --push develop
+        run: uv run mike deploy --push --update-aliases "${{ github.ref_name }}" latest
       - name: List available docs versions
         run: uv run mike list


### PR DESCRIPTION
* Add a GitHub issue template for bug reports.
* Add a GitHub issue template for tagging releases.
* Update the `tag` workflow to make sure that when updating the docs, the new version is added and set to the latest.