### PR TITLE
Add tax fields to record types

### DIFF
--- a/changelog.d/22.added.md
+++ b/changelog.d/22.added.md
@@ -1,0 +1,1 @@
+Add tax fields to record types

--- a/docs/managers/account-move-line.md
+++ b/docs/managers/account-move-line.md
@@ -241,3 +241,27 @@ quantity: float
 ```
 
 Quantity of product charged on the account move (invoice) line.
+
+### `tax_ids`
+
+```python
+tax_ids: list[int]
+```
+
+The list of IDs for the taxes that are applied
+on this account move (invoice) line.
+
+*Added in version 0.2.3.*
+
+### `taxes`
+
+```python
+taxes: list[Tax]
+```
+
+The list of taxes that are applied on this account move (invoice) line.
+
+This fetches the full records from Odoo once,
+and caches them for subsequent accesses.
+
+*Added in version 0.2.3.*

--- a/docs/managers/product.md
+++ b/docs/managers/product.md
@@ -375,6 +375,40 @@ Whether or not this product is sellable.
 
 *Added in version 0.2.1.*
 
+### `tax_ids`
+
+```python
+tax_ids: list[int]
+```
+
+An alias for [``taxes_id``](#taxes_id).
+
+*Added in version 0.2.3.*
+
+### `taxes_id`
+
+```python
+taxes_id: list[int]
+```
+
+The list of IDs for the default taxes that are used
+when selling this product.
+
+*Added in version 0.2.3.*
+
+### `taxes`
+
+```python
+taxes: list[Tax]
+```
+
+The list of default taxes used when selling this product.
+
+This fetches the full records from Odoo once,
+and caches them for subsequent accesses.
+
+*Added in version 0.2.3.*
+
 ### `uom_id`
 
 ```python

--- a/openstack_odooclient/managers/account_move_line.py
+++ b/openstack_odooclient/managers/account_move_line.py
@@ -130,6 +130,22 @@ class AccountMoveLine(RecordBase["AccountMoveLineManager"]):
     quantity: float
     """Quantity of product charged on the account move (invoice) line."""
 
+    tax_ids: Annotated[list[int], ModelRef("tax_ids", Tax)]
+    """The list of IDs for the taxes that are applied
+    on this account move (invoice) line.
+
+    *Added in version 0.2.3.*
+    """
+
+    taxes: Annotated[list[Tax], ModelRef("tax_ids", Tax)]
+    """The list of taxes that are applied on this account move (invoice) line.
+
+    This fetches the full records from Odoo once,
+    and caches them for subsequent accesses.
+
+    *Added in version 0.2.3.*
+    """
+
 
 class AccountMoveLineManager(RecordManagerBase[AccountMoveLine]):
     env_name = "account.move.line"
@@ -141,3 +157,4 @@ from .account_move import AccountMove  # noqa: E402
 from .currency import Currency  # noqa: E402
 from .product import Product  # noqa: E402
 from .project import Project  # noqa: E402
+from .tax import Tax  # noqa: E402

--- a/openstack_odooclient/managers/product.py
+++ b/openstack_odooclient/managers/product.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Annotated, Any, Literal, overload
 
 from ..base.record.base import RecordBase
-from ..base.record.types import ModelRef
+from ..base.record.types import FieldAlias, ModelRef
 from ..base.record_manager.base import RecordManagerBase
 
 if TYPE_CHECKING:
@@ -86,6 +86,28 @@ class Product(RecordBase["ProductManager"]):
     """Whether or not this product is sellable.
 
     *Added in version 0.2.1.*
+    """
+
+    tax_ids: Annotated[list[int], FieldAlias("taxes_id")]
+    """An alias for ``taxes_id``.
+
+    *Added in version 0.2.3.*
+    """
+
+    taxes_id: Annotated[list[int], ModelRef("taxes_id", Tax)]
+    """The list of IDs for the default taxes that are used
+    when selling this product.
+
+    *Added in version 0.2.3.*
+    """
+
+    taxes: Annotated[list[Tax], ModelRef("taxes_id", Tax)]
+    """The list of default taxes used when selling this product.
+
+    This fetches the full records from Odoo once,
+    and caches them for subsequent accesses.
+
+    *Added in version 0.2.3.*
     """
 
     uom_id: Annotated[int, ModelRef("uom_id", Uom)]
@@ -366,4 +388,5 @@ class ProductManager(RecordManagerBase[Product]):
 # NOTE(callumdickinson): Import here to make sure circular imports work.
 from .company import Company  # noqa: E402
 from .product_category import ProductCategory  # noqa: E402
+from .tax import Tax  # noqa: E402
 from .uom import Uom  # noqa: E402


### PR DESCRIPTION
* Add the ``taxes_id`` (with ``tax_ids`` alias) and ``taxes`` fields to the ``Product`` record type.
* Add the ``tax_ids`` and ``taxes`` fields to the ``AccountMoveLine`` record type.