### PR TITLE
Fix attachment model refs

### DIFF
--- a/changelog.d/28.fixed.md
+++ b/changelog.d/28.fixed.md
@@ -1,0 +1,1 @@
+Fix attachment model refs

--- a/docs/managers/custom.md
+++ b/docs/managers/custom.md
@@ -964,13 +964,13 @@ class CustomRecord(
     #
     # message_main_attachment_name: Annotated[
     #     str | None,
-    #     ModelRef("message_main_attachment_name", Attachment),
+    #     ModelRef("message_main_attachment_id", Attachment),
     # ]
     # """The name of the main attachment on the record, if there is one."""
     #
     # message_main_attachment: Annotated[
     #     Attachment | None,
-    #     ModelRef("message_main_attachment", Attachment),
+    #     ModelRef("message_main_attachment_id", Attachment),
     # ]
     # """The main attachment on the record, if there is one.
     #

--- a/openstack_odooclient/mixins/record_with_attachment.py
+++ b/openstack_odooclient/mixins/record_with_attachment.py
@@ -39,13 +39,13 @@ class RecordWithAttachmentMixin(RecordProtocol[RM], Generic[RM]):
 
     message_main_attachment_name: Annotated[
         str | None,
-        ModelRef("message_main_attachment_name", Attachment),
+        ModelRef("message_main_attachment_id", Attachment),
     ]
     """The name of the main attachment on the record, if there is one."""
 
     message_main_attachment: Annotated[
         Attachment | None,
-        ModelRef("message_main_attachment", Attachment),
+        ModelRef("message_main_attachment_id", Attachment),
     ]
     """The main attachment on the record, if there is one.
 


### PR DESCRIPTION
Fix resolving model refs for the `message_main_attachment_name` and `message_main_attachment` fields.