### PR TITLE
Mark expiry_date fields as optional

### DIFF
--- a/changelog.d/31.fixed.md
+++ b/changelog.d/31.fixed.md
@@ -1,0 +1,1 @@
+Mark expiry_date fields as optional

--- a/docs/managers/credit.md
+++ b/docs/managers/credit.md
@@ -86,10 +86,10 @@ The current remaining balance on the credit.
 ### `expiry_date`
 
 ```python
-expiry_date: date
+expiry_date: date | Literal[False]
 ```
 
-The date the credit expires.
+The date the credit expires, if an expiry date is set.
 
 ### `initial_balance`
 

--- a/docs/managers/grant.md
+++ b/docs/managers/grant.md
@@ -51,10 +51,10 @@ see [Record Attributes and Methods](index.md#attributes-and-methods).
 ### `expiry_date`
 
 ```python
-expiry_date: date
+expiry_date: date | Literal[False]
 ```
 
-The date the grant expires.
+The date the grant expires, if an expiry date is set.
 
 ### `grant_type_id`
 

--- a/docs/managers/voucher-code.md
+++ b/docs/managers/voucher-code.md
@@ -145,7 +145,7 @@ and caches it for subsequent accesses.
 expiry_date: date | Literal[False]
 ```
 
-The date the voucher code expires.
+The date the voucher code expires, if an expiry date is set.
 
 ### `grant_duration`
 

--- a/openstack_odooclient/managers/credit.py
+++ b/openstack_odooclient/managers/credit.py
@@ -16,7 +16,7 @@
 from __future__ import annotations
 
 from datetime import date
-from typing import Annotated
+from typing import Annotated, Literal
 
 from ..base.record.base import RecordBase
 from ..base.record.types import ModelRef
@@ -40,8 +40,8 @@ class Credit(RecordBase["CreditManager"]):
     current_balance: float
     """The current remaining balance on the credit."""
 
-    expiry_date: date
-    """The date the credit expires."""
+    expiry_date: date | Literal[False]
+    """The date the credit expires, if an expiry date is set."""
 
     initial_balance: float
     """The initial balance this credit started off with."""

--- a/openstack_odooclient/managers/grant.py
+++ b/openstack_odooclient/managers/grant.py
@@ -16,7 +16,7 @@
 from __future__ import annotations
 
 from datetime import date
-from typing import Annotated
+from typing import Annotated, Literal
 
 from ..base.record.base import RecordBase
 from ..base.record.types import ModelRef
@@ -24,8 +24,8 @@ from ..base.record_manager.base import RecordManagerBase
 
 
 class Grant(RecordBase["GrantManager"]):
-    expiry_date: date
-    """The date the grant expires."""
+    expiry_date: date | Literal[False]
+    """The date the grant expires, if an expiry date is set."""
 
     grant_type_id: Annotated[int, ModelRef("grant_type", GrantType)]
     """The ID of the type of this grant."""

--- a/openstack_odooclient/managers/voucher_code.py
+++ b/openstack_odooclient/managers/voucher_code.py
@@ -91,7 +91,7 @@ class VoucherCode(
     """
 
     expiry_date: date | Literal[False]
-    """The date the voucher code expires."""
+    """The date the voucher code expires, if an expiry date is set."""
 
     grant_duration: int | Literal[False]
     """The duration of the grant, in days, if a grant is to be


### PR DESCRIPTION
All `expiry_date` fields are optional.

Fix their type hints and descriptions to reflect the fact they can not be set.